### PR TITLE
Update to 2019

### DIFF
--- a/sankaku-downloader.sh
+++ b/sankaku-downloader.sh
@@ -24,7 +24,7 @@ chan="https://chan.sankakucomplex.com"
 useragent="user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/71.0.3578.98 Chrome/71.0.3578.98 Safari/537.36"
 # Modify this to get from 26+ page (without login you can see only firsts 25)
 # Set your username and your password hashed (see in networks tab and get them from cookies)
-cookie='Cookie: locale=en; auto_page=1; login=Username; pass_hash=ed4f078hashedpassword;'
+cookie="Cookie: locale=en; auto_page=1; login=Username; pass_hash=ed4f078hashedpassword;"
 
 getResultPage() {
     curl -s "$chan/post/index.content?tags=$tags&page=$1" -H "$useragent" -H "$cookie"

--- a/sankaku-downloader.sh
+++ b/sankaku-downloader.sh
@@ -19,11 +19,12 @@ encodeURIComponent() {
 }
 
 tags="$(encodeURIComponent <<< "$1")"
-dirName="$(head -n1 <<< "$1" | sed -r 's#[\/:*?"<>|]#�#g')"
-chan='https://chan.sankakucomplex.com'
+dirName="$(head -n1 <<< "$1" | sed -r 's#[\/:*?\"<>|]#�#g')"
+chan="https://chan.sankakucomplex.com"
+useragent="user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/71.0.3578.98 Chrome/71.0.3578.98 Safari/537.36"
 
 getResultPage() {
-    curl -s "$chan/post/index.content?tags=$baseUrl$tags&page=$1"
+    curl -s "$chan/post/index.content?tags=$tags&page=$1" -H "$useragent"
 }
 
 pageNumber=0
@@ -39,13 +40,14 @@ getUrls() {
 }
 
 downloadPost() {
-    html="$(curl -s "$1")"
+    html="$(curl -s "$1" -H "$useragent")"
     if (($?)); then echo -n ' X'; return 1; fi
     re='cs\.sankakucomplex\.com/data/[a-f0-9]'
     sed="s#^.*($re)#https://\\1#;s/\".*\$//"
     url="$(grep -E "$re" <<< "$html" | head -n1 | sed -r "$sed")"
+    url="$(sed 's/amp;//g' <<< $url)"
     fileName="$(sed 's#^.*/##;s/\?.*$//' <<< "$url")"
-    curl -s "$url" > "$dirName/$fileName"
+    curl -s "$url" -H "$useragent" > "$dirName/$fileName"
     if (($?)); then echo -n ' X'; return 1; fi
     echo -n ' ✓'
 }

--- a/sankaku-downloader.sh
+++ b/sankaku-downloader.sh
@@ -22,9 +22,12 @@ tags="$(encodeURIComponent <<< "$1")"
 dirName="$(head -n1 <<< "$1" | sed -r 's#[\/:*?\"<>|]#�#g')"
 chan="https://chan.sankakucomplex.com"
 useragent="user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/71.0.3578.98 Chrome/71.0.3578.98 Safari/537.36"
+# Modify this to get from 26+ page (without login you can see only firsts 25)
+# Set your username and your password hashed (see in networks tab and get them from cookies)
+cookie='Cookie: locale=en; auto_page=1; login=Username; pass_hash=ed4f078hashedpassword;'
 
 getResultPage() {
-    curl -s "$chan/post/index.content?tags=$tags&page=$1" -H "$useragent"
+    curl -s "$chan/post/index.content?tags=$tags&page=$1" -H "$useragent" -H "$cookie"
 }
 
 pageNumber=0


### PR DESCRIPTION
Sankaku now returns error 500 if you use an user-agent like curl or wget. So you have to add a fake user-agent to the request. Moreover, there is a need of to replace "&amp;" with "&" (if the post shows an image "sample" instead of "original" there is a "&amp;" instead of "&" in the Sankaku's html source.